### PR TITLE
Add digital_asset_authorized_clicks and digital_asset_authorized_days to Store factory

### DIFF
--- a/core/lib/spree/testing_support/factories/store_factory.rb
+++ b/core/lib/spree/testing_support/factories/store_factory.rb
@@ -13,6 +13,8 @@ FactoryBot.define do
     twitter                { 'spreecommerce' }
     instagram              { 'spreecommerce' }
     meta_description       { 'Sample store description.' }
+    digital_asset_authorized_clicks { 5 }
+    digital_asset_authorized_days   { 7 }
 
     trait :with_favicon do
       transient do


### PR DESCRIPTION
These two were missing which was causing a following error when using a `create(:store)`. This it the error it solves:

```
Failure/Error: raise(RecordInvalid.new(self))
     
     ActiveRecord::RecordInvalid:
       Validation failed: Digital asset authorized clicks is not a number, Digital asset authorized days is not a number
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/validations.rb:80:in `raise_validation_error'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/validations.rb:53:in `save!'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/transactions.rb:302:in `block in save!'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/transactions.rb:354:in `block in with_transaction_returning_status'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/connection_adapters/abstract/transaction.rb:319:in `block in within_new_transaction'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activesupport-7.0.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `handle_interrupt'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activesupport-7.0.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:25:in `block in synchronize'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activesupport-7.0.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `handle_interrupt'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activesupport-7.0.6/lib/active_support/concurrency/load_interlock_aware_monitor.rb:21:in `synchronize'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/connection_adapters/abstract/transaction.rb:317:in `within_new_transaction'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/connection_adapters/abstract/database_statements.rb:316:in `transaction'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/transactions.rb:350:in `with_transaction_returning_status'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/transactions.rb:302:in `save!'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activerecord-7.0.6/lib/active_record/suppressor.rb:54:in `save!'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/configuration.rb:18:in `block in initialize'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/evaluation.rb:18:in `create'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy/create.rb:12:in `block in result'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy/create.rb:9:in `result'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/factory.rb:43:in `run'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/factory_runner.rb:29:in `block in run'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/activesupport-7.0.6/lib/active_support/notifications.rb:208:in `instrument'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/factory_runner.rb:28:in `run'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/factory_bot-4.11.1/lib/factory_bot/strategy_syntax_method_registrar.rb:20:in `block in define_singular_strategy_method'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/spree_dev_tools-0.2.0/lib/spree_dev_tools/rspec/support/spree.rb:59:in `block (2 levels) in <top (required)>'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/webmock-3.18.1/lib/webmock/rspec.rb:37:in `block (2 levels) in <top (required)>'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:124:in `block in run'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `loop'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:110:in `run'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/rspec-retry-0.6.2/lib/rspec_ext/rspec_ext.rb:12:in `run_with_retry'
     # /Users/mbajur/.rvm/gems/ruby-3.2.0/gems/rspec-retry-0.6.2/lib/rspec/retry.rb:37:in `block (2 levels) in setup'
```